### PR TITLE
PAV-300 - feature - sorting over all rows

### DIFF
--- a/server/controllers/phoenix.js
+++ b/server/controllers/phoenix.js
@@ -22,7 +22,7 @@ let phoenix = (() => {
           break;
         case 'jobs' :
           options = {
-            url: config.pavics_phoenix_path + '/monitor?limit=100',
+            url: config.pavics_phoenix_path + '/monitor?limit=1000',
             headers: {
               Accept: 'application/json'
             },

--- a/src/components/Monitor/JobTable.js
+++ b/src/components/Monitor/JobTable.js
@@ -26,26 +26,45 @@ class JobTable extends React.Component {
     if (this.api) {
       this.api.sizeColumnsToFit();
     }
+    this.api.setDatasource(this.datasource());
   };
 
   datasource = () => {
-    return {
-      getRows: (params: IGetRowsParams) => {
-        let rowCount = this.props.jobs.length;
-        let rows = [];
-        for (let i = params.startRow; i < params.endRow; i++) {
-          if (this.props.jobs[i]) {
-            rows.push(this.props.jobs[i]);
+    let sortData = (sortModel) => {
+      if (sortModel && sortModel.length > 0) {
+        let sortResult = this.props.jobs.slice();
+        sortResult.sort((elemA, elemB) => {
+          for (let i = 0, nbColumns = sortModel.length; i < nbColumns; i++) {
+            let columnModel = sortModel[i];
+            let valA = elemA[columnModel.colId];
+            let valB = elemB[columnModel.colId];
+            if (valA === valB) {
+              continue;
+            }
+            let sortDirection = columnModel.sort === 'asc' ? 1 : -1;
+            if (valA > valB) {
+              return sortDirection;
+            } else {
+              return sortDirection * -1;
+            }
           }
-        }
-        params.successCallback(rows, rowCount);
+          return 0;
+        });
+        return sortResult;
+      }
+      return this.props.jobs;
+    };
+    return {
+      rowCount: this.props.jobs.length,
+      getRows: (params: IGetRowsParams) => {
+        let sortedData = sortData(params.sortModel);
+        params.successCallback(sortedData.slice(params.startRow, params.endRow));
       }
     };
   };
 
   onGridReady = (params) => {
     this.api = params.api;
-    this.api.setDatasource(this.datasource());
   };
 
   render () {
@@ -58,12 +77,11 @@ class JobTable extends React.Component {
                 <AgGridReact
                   onGridReady={this.onGridReady}
                   className={classes.agGrid}
-                  rowData={this.props.jobs}
                   columnDefs={this.columnDefs()}
                   rowModelType="pagination"
                   paginationPageSize={10}
                   rowHeight={25}
-                  enableSorting
+                  enableServerSideSorting
                 />
               </div>
             </Panel>


### PR DESCRIPTION
on télécharge tout le data des jobs et après on manage le state client side

ag-grid appelle ça serverSideSorting seulement dans le sens où c'est le datasource qui s'occupe du sorting. à terme on pourrait refactor pour que le serveur prenne des paramètres, mais vraiment pas prioritaire, et possiblement jamais fait: ça implique de changer Phoenix pas mal