### PR TITLE
PAV-403 - datetime inputs in wps form

### DIFF
--- a/src/components/WpsProcessForm/WpsProcessForm.js
+++ b/src/components/WpsProcessForm/WpsProcessForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import DeformWrapper from '../DeformWrapper/DeformWrapper';
-import WpsProcessFormInput from '../WpsProcessFormInput/WpsProcessFormInput';
 import * as constants from './../../constants';
+
+const {WpsProcessFormInput} = require('../WpsProcessFormInput/WpsProcessFormInput');
 
 /*
 Wps Process Form

--- a/src/components/WpsProcessFormInput/WpsProcessFormInput.js
+++ b/src/components/WpsProcessFormInput/WpsProcessFormInput.js
@@ -33,10 +33,10 @@ class WpsProcessFormInput extends Component {
   }
 
   createDateTime = () => {
-    const date = this.state.dateTimeValues.date;
-    const time = this.state.dateTimeValues.time;
-    const dateString = date ? date.toISOString().split('T')[0] : '';
-    const timeString = time ? time.toISOString().split('T')[1] : '';
+    const date = this.state.dateTimeValues.date || new Date();
+    const time = this.state.dateTimeValues.time || new Date();
+    const dateString = date.toISOString().split('T')[0];
+    const timeString = time.toISOString().split('T')[1];
     this.props.handleChange(`${dateString}T${timeString}`, this.props.uniqueIdentifier);
   };
   handleDateChange = (event, date) => {
@@ -56,10 +56,27 @@ class WpsProcessFormInput extends Component {
     }, () => { this.createDateTime(); });
   };
 
-  // it seems the dataType property of the inputs might change unpredictably (we have seen three forms to date) but they all seem to end with the type
-  // hence, for string and boolean, implement a type of "endsWith" check instead of pure equivalence
+  handleCheckboxChange = (event, value) => {
+    this.props.handleChange(event.target.checked, this.props.uniqueIdentifier);
+  };
+
+  createHandleTextFieldArrayChangeCallback = (index) => {
+    return (event, value) => {
+      this.handleTextFieldArrayChange(event.target.value, index);
+    };
+  };
+
+  handleTextFieldArrayChange = (value, index) => {
+    this.props.handleArrayChange(value, this.props.uniqueIdentifier, index);
+  };
+
+  handleTextFieldChange = (event, value) => {
+    this.props.handleChange(event.target.value, this.props.uniqueIdentifier);
+  };
 
   createMarkup () {
+    // it seems the dataType property of the inputs might change unpredictably (we have seen three forms to date) but they all seem to end with the type
+    // hence, for string and boolean, implement a type of "endsWith" check instead of pure equivalence
     if (this.props.type.endsWith(BOOLEAN)) {
       let value = false;
       if (typeof (this.props.value) === 'boolean') {
@@ -77,7 +94,7 @@ class WpsProcessFormInput extends Component {
             labelPosition="right"
             labelStyle={{ textAlign: 'left' }}
             checked={value}
-            onCheck={(event, value) => this.props.handleChange(event.target.checked, this.props.uniqueIdentifier)}
+            onCheck={this.handleCheckboxChange}
             value={value} />
           <small>{this.props.description}</small>
         </div>
@@ -93,13 +110,14 @@ class WpsProcessFormInput extends Component {
                 value={this.state.dateTimeValues.date}
                 onChange={this.handleDateChange}
                 style={{ width: '100%' }}
-                hintText={this.props.description}
+                hintText={`${this.props.description} - date`}
                 container="inline" />
             </div>
             <div className="col-sm-6">
               <TimePicker
                 autoOk
                 value={this.state.dateTimeValues.time}
+                hintText={`${this.props.description} - time`}
                 onChange={this.handleTimeChange}
                 textFieldStyle={{ width: '100%' }}
                 format="24hr" />
@@ -117,7 +135,7 @@ class WpsProcessFormInput extends Component {
             name={this.props.name}
             fullWidth
             value={this.props.value[i]}
-            onChange={(event, value) => this.props.handleArrayChange(event.target.value, this.props.uniqueIdentifier, i)}
+            onChange={this.createHandleTextFieldArrayChangeCallback(i)}
             hintText={this.props.description}
             floatingLabelText={this.props.title} />
         );
@@ -128,7 +146,7 @@ class WpsProcessFormInput extends Component {
         name={this.props.name}
         fullWidth
         value={this.props.value}
-        onChange={(event, value) => this.props.handleChange(event.target.value, this.props.uniqueIdentifier)}
+        onChange={this.handleTextFieldChange}
         hintText={this.props.description}
         floatingLabelText={this.props.title} />
     );

--- a/src/components/WpsProcessFormInput/WpsProcessFormInput.js
+++ b/src/components/WpsProcessFormInput/WpsProcessFormInput.js
@@ -1,9 +1,12 @@
 import React, {Component} from 'react';
 import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
-import * as constants from './../../constants';
+import DatePicker from 'material-ui/DatePicker';
+import TimePicker from 'material-ui/TimePicker';
 
-export default class WpsProcessFormInput extends Component {
+const {BOOLEAN, INPUT_DATETIME} = require('../../constants');
+
+class WpsProcessFormInput extends Component {
 
   // value not marked as required because it can (somewhat) validly be undefined
   static propTypes = {
@@ -19,11 +22,45 @@ export default class WpsProcessFormInput extends Component {
     value: React.PropTypes.any
   };
 
+  constructor (props) {
+    super(props);
+    this.state = {
+      dateTimeValues: {
+        date: null,
+        time: null
+      }
+    };
+  }
+
+  createDateTime = () => {
+    const date = this.state.dateTimeValues.date;
+    const time = this.state.dateTimeValues.time;
+    const dateString = date ? date.toISOString().split('T')[0] : '';
+    const timeString = time ? time.toISOString().split('T')[1] : '';
+    this.props.handleChange(`${dateString}T${timeString}`, this.props.uniqueIdentifier);
+  };
+  handleDateChange = (event, date) => {
+    this.setState({
+      dateTimeValues: {
+        date: date,
+        time: this.state.dateTimeValues.time
+      }
+    }, () => { this.createDateTime(); });
+  };
+  handleTimeChange = (event, time) => {
+    this.setState({
+      dateTimeValues: {
+        date: this.state.dateTimeValues.date,
+        time: time
+      }
+    }, () => { this.createDateTime(); });
+  };
+
   // it seems the dataType property of the inputs might change unpredictably (we have seen three forms to date) but they all seem to end with the type
   // hence, for string and boolean, implement a type of "endsWith" check instead of pure equivalence
 
   createMarkup () {
-    if (this.props.type.endsWith(constants.BOOLEAN)) {
+    if (this.props.type.endsWith(BOOLEAN)) {
       let value = false;
       if (typeof (this.props.value) === 'boolean') {
         value = this.props.value;
@@ -43,6 +80,32 @@ export default class WpsProcessFormInput extends Component {
             onCheck={(event, value) => this.props.handleChange(event.target.checked, this.props.uniqueIdentifier)}
             value={value} />
           <small>{this.props.description}</small>
+        </div>
+      );
+    }
+    if (this.props.type === INPUT_DATETIME) {
+      return (
+        <div style={{ padding: '15px 0 0' }} className="container">
+          <div className="row">
+            <div className="col-sm-6">
+              <DatePicker
+                autoOk
+                value={this.state.dateTimeValues.date}
+                onChange={this.handleDateChange}
+                style={{ width: '100%' }}
+                hintText={this.props.description}
+                container="inline" />
+            </div>
+            <div className="col-sm-6">
+              <TimePicker
+                autoOk
+                value={this.state.dateTimeValues.time}
+                onChange={this.handleTimeChange}
+                textFieldStyle={{ width: '100%' }}
+                format="24hr" />
+            </div>
+            <input value={this.props.value} name={this.props.name} title={this.props.title} type="hidden" />
+          </div>
         </div>
       );
     }
@@ -81,3 +144,5 @@ export default class WpsProcessFormInput extends Component {
     );
   }
 }
+
+export {WpsProcessFormInput};

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ export const DEFAULT_SELECTED_KEY = 'frequency';
 export const PER_PAGE_OPTIONS = [5, 10, 25];
 export const PER_PAGE_INITIAL_INDEX = 0;
 // WPS processes and forms
+export const INPUT_DATETIME = 'dateTime';
 export const BOOLEAN = 'boolean';
 export const STRING = 'string';
 export const NETCDF = 'ComplexData';


### PR DESCRIPTION
This adds a custom type of input to the wps forms. We use both the datepicker and timepicker from material to create a single date time string.