### PR TITLE
Docker images won't be runnig webpack dev server anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ ADD package-lock.json package-lock.json
 RUN npm install
 ADD . .
 
-CMD ["npm","start"]
+CMD /bin/bash ./bin/startup.sh
 EXPOSE 3000

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export NODE_ENV=production
+npm run compile
+npm start


### PR DESCRIPTION
No more webpackDevMiddleware & webpackHMRMiddleware running in prod which were causing the error. 
The error itself couldn't be fixed and will still happen sometimes in dev
Added ENV=production
https://github.com/Ouranosinc/PAVICS-frontend/issues/98